### PR TITLE
Fix crash with Android 12 (S, API 31).

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,11 +37,11 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.appcompat:appcompat:1.4.0'
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'com.evernote:android-job:1.4.2'
-    implementation 'androidx.work:work-runtime:2.6.0'
+    implementation 'androidx.work:work-runtime:2.7.1'
     implementation "com.github.clans:fab:1.6.4"
     implementation "com.github.jorgecastilloprz:fabprogresscircle:1.01"
     implementation "com.google.android.gms:play-services-analytics:17.0.1"

--- a/app/src/main/java/com/bige0/shadowsocksr/ShadowsocksNotification.kt
+++ b/app/src/main/java/com/bige0/shadowsocksr/ShadowsocksNotification.kt
@@ -1,6 +1,7 @@
 package com.bige0.shadowsocksr
 
 import android.app.*
+import android.app.PendingIntent.*
 import android.content.*
 import android.os.*
 import androidx.core.app.*
@@ -190,17 +191,17 @@ class ShadowsocksNotification constructor(private val service: Service, private 
 			.setTicker(service.getString(R.string.forward_success))
 			.setContentTitle(profileName)
 			.setContentIntent(PendingIntent.getActivity(service, 0, Intent(service, Shadowsocks::class.java)
-				.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT), 0))
+				.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT), FLAG_IMMUTABLE))
 			.setSmallIcon(R.drawable.ic_stat_shadowsocks)
 		builder.addAction(R.drawable.ic_navigation_close,
 						  service.getString(R.string.stop),
-						  PendingIntent.getBroadcast(service, 0, Intent(Constants.Action.CLOSE), 0))
+						  PendingIntent.getBroadcast(service, 0, Intent(Constants.Action.CLOSE), FLAG_IMMUTABLE))
 
 		val profiles = ShadowsocksApplication.app.profileManager.allProfiles
 		if (profiles.isNotEmpty())
 		{
 			builder.addAction(R.drawable.ic_action_settings, service.getString(R.string.quick_switch),
-							  PendingIntent.getActivity(service, 0, Intent(Constants.Action.QUICK_SWITCH), 0))
+							  PendingIntent.getActivity(service, 0, Intent(Constants.Action.QUICK_SWITCH), FLAG_IMMUTABLE))
 		}
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         maven  { url 'https://maven.aliyun.com/repository/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.0.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
As app seems don't need to send data back in Notification Area, these required flag field are now all FLAG_IMMUTABLE.
Also dump up dependencies version as some of them violates this requirement too (Ehh..)

感想就是，谷歌，你为什么